### PR TITLE
Missing Visual C++ redistributable requirement

### DIFF
--- a/WeiDU/TobEx/TobEx_redist/readme/readme.htm
+++ b/WeiDU/TobEx/TobEx_redist/readme/readme.htm
@@ -357,6 +357,7 @@
         <div class="content">
           <h2>Requirements</h2>
           <p>TobEx requires Baldur's Gate II: Throne of Bhaal version 26498. The modification will not work on other versions of Throne of Bhaal.</p>
+	  <p>On Windows, TobEx requires the Visual Studio 2010 (VC++ 10.0) SP1 redistributable to be installed.</p>
           <p>TobEx is programmed and primarily tested on Windows sytems. It may work on Linux systems, and is unlikely to work on Macintosh systems.</p>
           <address>
             <span class="footer">TobEx &gt; Requirements</span> &#8226;<a href="#top">BACK TO TOP</a>


### PR DESCRIPTION
The latest C++ redistributable _did not_ work, neither did the 2008.

With the mentioned redist, TobEx console appeared normally.